### PR TITLE
Added optional argument to TessEphem.ephem for the DVA

### DIFF
--- a/src/tess_ephem/ephem.py
+++ b/src/tess_ephem/ephem.py
@@ -161,8 +161,7 @@ def ephem(
     interpolation_step : str
         Resolution at which ephemeris data will be obtained from JPL Horizons.
     aberrate: bool
-        If True then use tess-point's approximate DVA when computing the sky coordinates.
-        Note this only changes the returned R.A. and Decl. when verbose=True.
+        If True then use tess-point's approximate DVA when computing the pixel coordinates.
 
     Returns
     -------

--- a/src/tess_ephem/ephem.py
+++ b/src/tess_ephem/ephem.py
@@ -96,11 +96,11 @@ class TessEphem:
             }
         )
 
-    def predict(self, time: Time, verbose: bool = False) -> DataFrame:
+    def predict(self, time: Time, aberrate: bool = True, verbose: bool = False) -> DataFrame:
         sky = self.predict_sky(time)
         crd = SkyCoord(sky.ra, sky.dec, unit="deg")
         log.info("Started matching the ephemeris to TESS observations")
-        locresult = locate(crd, time=time)
+        locresult = locate(crd, time=time, aberrate=aberrate)
         df = locresult.to_pandas().merge(sky, on="time", how="inner")
         df = df.set_index("time")
         if not verbose:
@@ -139,6 +139,7 @@ def ephem(
     verbose: bool = False,
     id_type: str = "smallbody",
     interpolation_step: str = "12H",
+    aberrate: bool = True
 ) -> DataFrame:
     """Returns the ephemeris of a Solar System body in the TESS FFI data set.
 
@@ -185,4 +186,4 @@ def ephem(
     te = TessEphem(
         target, start=start, stop=stop, step=interpolation_step, id_type=id_type
     )
-    return te.predict(time=time, verbose=verbose)
+    return te.predict(time=time, aberrate=aberrate, verbose=verbose)

--- a/src/tess_ephem/ephem.py
+++ b/src/tess_ephem/ephem.py
@@ -160,6 +160,9 @@ def ephem(
         "comet_name", or "designation".
     interpolation_step : str
         Resolution at which ephemeris data will be obtained from JPL Horizons.
+    aberrate: bool
+        If True then use tess-point's approximate DVA when computing the sky coordinates.
+        Note this only changes the returned R.A. and Decl. when verbose=True.
 
     Returns
     -------


### PR DESCRIPTION
When calling ephem computing the approximate DVA via tess-point is now optional when returning the JPL Horizons R.A. and Decl.