### PR TITLE
Replace tess-locator with tesswcs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -28,22 +28,27 @@ Example use
 -----------
 
 tess-ephem allows you to search the entire archive of TESS FFI's for the presence
-of a known minor planet, and obtain the result as a Pandas DataFrame.
-For example:
+of a known minor planet, and obtain the result as a Pandas DataFrame. The output pixel coordinates (column and row) follow the TESS convention, with (1,1) being the middle of the pixel in the lower left corner of the FFI. For example:
 
 .. code-block:: python
 
     >>> from tess_ephem import ephem
     >>> ephem("Sedna")
-                             sector  camera  ccd       column          row
-    time
-    2018-11-16 00:00:00.000       5       1    4  1543.312296  1102.821559
-    2018-11-17 00:00:00.000       5       1    4  1545.160910  1102.880825
-    2018-11-18 00:00:00.000       5       1    4  1547.011351  1102.934375
-    ...
-    2018-12-09 00:00:00.000       5       1    4  1584.585407  1102.239292
-    2018-12-10 00:00:00.000       5       1    4  1586.245261  1102.132304
-    2018-12-11 00:00:00.000       5       1    4  1587.906380  1102.012091
+               sector  camera  ccd       column          row
+    time                                                    
+    2458437.5       5       1    4  1540.328759  1102.742761
+    2458438.5       5       1    4  1542.057935  1102.906116
+    2458439.5       5       1    4  1543.919678  1102.977150
+    2458440.5       5       1    4  1545.806011  1103.011147
+    2458441.5       5       1    4  1547.691635  1103.029184
+    ...           ...     ...  ...          ...          ...
+    2460254.5      71       2    4  1984.472509  1004.531966
+    2460255.5      71       2    4  1984.704905  1002.716266
+    2460256.5      71       2    4  1984.934016  1000.892089
+    2460257.5      71       2    4  1985.160431   999.062904
+    2460258.5      71       2    4  1985.376804   997.240991
+
+    [78 rows x 5 columns]
 
 
 You can also obtain the ephemeris for one or more specific times
@@ -53,8 +58,15 @@ by passing the `time` parameter:
 
     >>> ephem("Sedna", time="2018-11-21 17:35:00")
                              sector  camera  ccd       column          row
-    time
-    2018-11-21 17:35:00.000       5       1    4  1553.887838  1103.048431
+    time                                                                  
+    2018-11-21 17:35:00.000       5       1    4  1552.813087  1103.033716
+
+    >>> from astropy.time import Time
+    >>> ephem("Sedna", time=Time([2458441.5,2460258.5], format='jd'))
+               sector  camera  ccd       column          row
+    time                                                    
+    2458441.5       5       1    4  1547.691635  1103.029184
+    2460258.5      71       2    4  1985.376804   997.240991
 
 
 Additional physical parameters can be obtained by passing the `verbose=True` parameter:
@@ -63,5 +75,62 @@ Additional physical parameters can be obtained by passing the `verbose=True` par
 
     >>> ephem("Sedna", time="2018-11-21 17:35:00", verbose=True)
                              sector  camera  ccd       column          row  pixels_per_hour        ra      dec    vmag  sun_distance  obs_distance  phase_angle
-    time
-    2018-11-21 17:35:00.000       5       1    4  1553.887838  1103.048431         0.074054  57.05786  7.63721  20.612     84.942885     83.975689       0.1419
+    time                                                                                                                                                       
+    2018-11-21 17:35:00.000       5       1    4  1552.813087  1103.033716         0.074053  57.06362  7.63836  20.812     84.943049     83.975854       0.1419
+
+
+You can alternatively obtain the ephemeris during a specific sector by passing 
+the `sector` parameter:
+
+.. code-block:: python
+
+    >>> ephem("Sedna", sector=70)
+               sector  camera  ccd       column          row
+    time                                                    
+    2460208.5      70       4    2  1965.819900  1827.440280
+    2460209.5      70       4    2  1966.122988  1826.880450
+    2460210.5      70       4    2  1966.445615  1826.219237
+    2460211.5      70       4    2  1966.792833  1825.480366
+    2460212.5      70       4    2  1967.156084  1824.685065
+    2460213.5      70       4    2  1967.530374  1823.844978
+    2460214.5      70       4    2  1967.912846  1822.964230
+    2460215.5      70       4    2  1968.300642  1822.046948
+    2460216.5      70       4    2  1968.693056  1821.098583
+    2460217.5      70       4    2  1969.085076  1820.121939
+    2460218.5      70       4    2  1969.477787  1819.122100
+    2460219.5      70       4    2  1969.865471  1818.107325
+    2460220.5      70       4    2  1970.236706  1817.102989
+    2460221.5      70       4    2  1970.537507  1816.171600
+    2460222.5      70       4    2  1970.786337  1815.215528
+    2460223.5      70       4    2  1971.057940  1814.164426
+    2460224.5      70       4    2  1971.352361  1813.044830
+    2460225.5      70       4    2  1971.660316  1811.874587
+    2460226.5      70       4    2  1971.976449  1810.663652
+    2460227.5      70       4    2  1972.300053  1809.417480
+    2460228.5      70       4    2  1972.626477  1808.140569
+    2460229.5      70       4    2  1972.954292  1806.834984
+    2460230.5      70       4    2  1973.282790  1805.506180
+    2460231.5      70       4    2  1973.609473  1804.159986
+    2460232.5      70       4    2  1973.931842  1802.802230
+
+
+When passing the `sector` parameter, the `time_step` is by default 1 day. 
+This can be changed as follows:
+
+    >>> ephem("Sedna", sector=70, time_step=0.1)
+               sector  camera  ccd       column          row
+    time                                                    
+    2460207.6      70       4    2  1965.495431  1827.937212
+    2460207.7      70       4    2  1965.535648  1827.878206
+    2460207.8      70       4    2  1965.575019  1827.820108
+    2460207.9      70       4    2  1965.613392  1827.763020
+    2460208.0      70       4    2  1965.650616  1827.707041
+    ...           ...     ...  ...          ...          ...
+    2460233.0      70       4    2  1974.086940  1802.125478
+    2460233.1      70       4    2  1974.117634  1801.990490
+    2460233.2      70       4    2  1974.148118  1801.855903
+    2460233.3      70       4    2  1974.178192  1801.721961
+    2460233.4      70       4    2  1974.207660  1801.588906
+
+    [259 rows x 5 columns]
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,13 @@
 [tool.poetry]
 name = "tess-ephem"
-version = "0.4.0"
+version = "0.5.0"
 description = "Where are Solar System objects located in TESS FFI data?"
 license = "MIT"
 authors = ["Geert Barentsen <hello@geert.io>",
            "Christina Hedges",
            "Jorge Martinez-Palomera",
-           "Jessie Dotson"]
+           "Jessie Dotson",
+           "Amy Tuson"]
 readme = "README.rst"
 homepage = "https://github.com/SSDataLab/tess-ephem"
 repository = "https://github.com/SSDataLab/tess-ephem"
@@ -17,26 +18,25 @@ classifiers = [
 ]
 
 [tool.poetry.dependencies]
-python = "^3.8"
+python = "^3.9"
 scipy = "^1.9.0"
 astroquery = "0.4.6"
 numpy = "^1.23.0"
 pandas = "^1.4.4"
 astropy = "^5.2.0"
-tess-locator = "^0.6"
+tesswcs = "^1.1.3"
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev]
+optional = true
+
+[tool.poetry.group.dev.dependencies]
 pytest = "^6.1.2"
 jupyterlab = "^2.2.9"
-line-profiler = "^3.1.0"
-mypy = "^0.790"
-flake8 = "^3.8.4"
-black = "^20.8b1"
-pytest-cov = "^2.10.1"
-pytest-xdist = "^2.1.0"
-isort = "^5.6.4"
 matplotlib = "^3.3.3"
-#tess-locator = {path = "../tess-locator", develop = true}
+black = "^24.8.0"
+isort = "^5.13.2"
+flake8 = "^7.1.1"
+mypy = "^1.11.1"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/src/tess_ephem/__init__.py
+++ b/src/tess_ephem/__init__.py
@@ -6,5 +6,5 @@ log.addHandler(logging.StreamHandler())
 
 from .ephem import ephem, TessEphem  # noqa: E402
 
-__version__ = "0.4.0"
+__version__ = "0.5.0"
 __all__ = ["ephem", "TessEphem"]

--- a/src/tess_ephem/angle.py
+++ b/src/tess_ephem/angle.py
@@ -1,4 +1,5 @@
 """Helper functions to deal with spherical angles."""
+
 from typing import Callable, Sequence
 
 import numpy as np

--- a/src/tess_ephem/ephem.py
+++ b/src/tess_ephem/ephem.py
@@ -16,7 +16,6 @@ from tess_locator.dates import get_sector_dates
 from .angle import create_angle_interpolator
 from . import log
 
-# test line
 
 class TessEphem:
     def __init__(

--- a/src/tess_ephem/ephem.py
+++ b/src/tess_ephem/ephem.py
@@ -153,7 +153,7 @@ class TessEphem:
     @staticmethod
     def from_sector(
         target: str,
-        sector: int | None,
+        sector: Optional[int] = None,
         id_type: str = "smallbody",
         step: str = "12H",
         return_time: bool = False,

--- a/src/tess_ephem/ephem.py
+++ b/src/tess_ephem/ephem.py
@@ -16,6 +16,7 @@ from tess_locator.dates import get_sector_dates
 from .angle import create_angle_interpolator
 from . import log
 
+# test line
 
 class TessEphem:
     def __init__(

--- a/src/tess_ephem/ephem.py
+++ b/src/tess_ephem/ephem.py
@@ -114,6 +114,11 @@ class TessEphem:
             One row for each time stamp that matched a TESS observation.
         """
 
+        if not isinstance(time, Time):
+            time = Time(time)
+        if time.isscalar:
+            time = time.reshape((1,))
+
         sky = self.predict_sky(time)
         crd = SkyCoord(sky.ra, sky.dec, unit="deg")
         log.info("Started matching the ephemeris to TESS observations")

--- a/src/tess_ephem/ephem.py
+++ b/src/tess_ephem/ephem.py
@@ -189,9 +189,8 @@ class TessEphem:
         # If no sector passed, use all sectors in pointings file.
         if sector is None:
             # Define start and stop using pointings file from tesswcs
-            start, stop = Time(pointings["Start"][0], format="jd"), Time(
-                pointings["End"][-1], format="jd"
-            )
+            start = Time(pointings["Start"][0], format="jd")
+            stop = Time(pointings["End"][-1], format="jd")
 
         else:
             # Sector must be in pointings
@@ -203,14 +202,12 @@ class TessEphem:
                 )
 
             # Define start and stop of sector using pointings file from tesswcs
-            start, stop = Time(
-                pointings[pointings["Sector"] == sector]["Start"][0], format="jd"
-            ), Time(pointings[pointings["Sector"] == sector]["End"][0], format="jd")
+            start = Time(pointings[pointings["Sector"] == sector]["Start"][0], format="jd")
+            stop = Time(pointings[pointings["Sector"] == sector]["End"][0], format="jd")
 
         # Buffer of one day on start, stop for future interpolation of ephemeris.
-        start_buffer, stop_buffer = start - TimeDelta(1, format="jd"), stop + TimeDelta(
-            1, format="jd"
-        )
+        start_buffer = start - TimeDelta(1, format="jd")
+        stop_buffer = stop + TimeDelta(1, format="jd")
 
         # Return TessEphem object (and start/stop, if return_time=True)
         if return_time:

--- a/src/tess_ephem/ephem.py
+++ b/src/tess_ephem/ephem.py
@@ -202,7 +202,9 @@ class TessEphem:
                 )
 
             # Define start and stop of sector using pointings file from tesswcs
-            start = Time(pointings[pointings["Sector"] == sector]["Start"][0], format="jd")
+            start = Time(
+                pointings[pointings["Sector"] == sector]["Start"][0], format="jd"
+            )
             stop = Time(pointings[pointings["Sector"] == sector]["End"][0], format="jd")
 
         # Buffer of one day on start, stop for future interpolation of ephemeris.

--- a/tests/test_ephem.py
+++ b/tests/test_ephem.py
@@ -1,10 +1,49 @@
-from tess_ephem import ephem
+from tess_ephem import ephem, TessEphem
+from astropy.time import Time, TimeDelta
+import numpy as np
 
 
 def test_comet():
-    """Does `ephem()` work for a comet identifier?
+    """
+    Does `ephem()` work for a comet identifier?
     Horizons provides a column called "Tmag" rather than "V" for a comet's
     total magnitude.  Let's make sure we support this!
     """
-    comet_ephem = ephem("90000700", time="2019-01-01", verbose=True)
-    "vmag" in comet_ephem.columns
+    comet_ephem = ephem("90000700", time="2021-08-21", verbose=True)
+    assert "vmag" in comet_ephem.columns
+
+
+def test_from_sector():
+    """
+    Check from_sector() pulls the correct start/stop time from the pointings.csv file.
+    """
+    _, start, stop = TessEphem.from_sector("1998 YT6", sector=6, return_time=True)
+    assert start.value == 2458463.5
+    assert stop.value == 2458490.5
+
+
+def test_predict():
+    """
+    Check predict() gives the expected output for an example asteroid.
+    """
+
+    # Get pixel location of asteroid "1998 YT6" at time 2458489.8075233004 JD (during sector 6)
+    t = Time(2458489.8075233004, format="jd")
+    ephem = TessEphem(
+        "1998 YT6",
+        start=t - TimeDelta(7, format="jd"),
+        stop=t + TimeDelta(7, format="jd"),
+    )
+    pixel_locations = ephem.predict(time=t)
+
+    assert len(pixel_locations) == 1
+    assert pixel_locations["sector"][0] == 6
+    assert pixel_locations["camera"][0] == 1
+    assert pixel_locations["ccd"][0] == 1
+
+    # Expected col, row calculated by:
+    # 1. using JPL/Horizons web interface to find RA,Dec of asteroid at time t.
+    # 2. using tessrip to get average WCS from sector/camera/ccd
+    # 3. converting RA,Dec to col,row with wcs_world2pix()
+    assert np.round(pixel_locations["row"][0], 1) == 1107.6
+    assert np.round(pixel_locations["column"][0], 1) == 1087.8


### PR DESCRIPTION
- Updated predict() function: uses tesswcs instead of tess-locator to determine the pixel location.
- Created from_sector() function that allows you to initialize a TessEphem object with a target and sector.
- In query to JPL Horizons, return astrometric RA, Dec instead of apparent RA, Dec. 
- Updated and added examples to README file. 
- Added tests to test_ephem.py for new functions.