### PR TITLE
Update to pandasv2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tess-ephem"
-version = "0.5.0"
+version = "0.5.1"
 description = "Where are Solar System objects located in TESS FFI data?"
 license = "MIT"
 authors = ["Geert Barentsen <hello@geert.io>",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ python = "^3.9"
 scipy = "^1.9.0"
 astroquery = "0.4.6"
 numpy = "^1.23.0"
-pandas = "^1.4.4"
+pandas = "^2.0"
 astropy = "^5.2.0"
 tesswcs = "^1.1.3"
 

--- a/src/tess_ephem/__init__.py
+++ b/src/tess_ephem/__init__.py
@@ -6,5 +6,5 @@ log.addHandler(logging.StreamHandler())
 
 from .ephem import ephem, TessEphem  # noqa: E402
 
-__version__ = "0.5.0"
+__version__ = "0.5.1"
 __all__ = ["ephem", "TessEphem"]

--- a/src/tess_ephem/ephem.py
+++ b/src/tess_ephem/ephem.py
@@ -136,7 +136,7 @@ class TessEphem:
                 continue
 
         if len(df) == 0:
-            print("Warning: Target not observed by TESS at defined times.")
+            log.warning("Warning: Target not observed by TESS at defined times.")
         else:
             # Make column names lowercase in df
             df.columns = [x.lower() for x in df.columns]

--- a/tests/test_ephem.py
+++ b/tests/test_ephem.py
@@ -37,13 +37,13 @@ def test_predict():
     pixel_locations = ephem.predict(time=t)
 
     assert len(pixel_locations) == 1
-    assert pixel_locations["sector"][0] == 6
-    assert pixel_locations["camera"][0] == 1
-    assert pixel_locations["ccd"][0] == 1
+    assert pixel_locations.iloc[0]["sector"] == 6
+    assert pixel_locations.iloc[0]["camera"] == 1
+    assert pixel_locations.iloc[0]["ccd"] == 1
 
     # Expected col, row calculated by:
     # 1. using JPL/Horizons web interface to find RA,Dec of asteroid at time t.
     # 2. using tessrip to get average WCS from sector/camera/ccd
     # 3. converting RA,Dec to col,row with wcs_world2pix()
-    assert np.round(pixel_locations["row"][0], 1) == 1107.6
-    assert np.round(pixel_locations["column"][0], 1) == 1087.8
+    assert np.round(pixel_locations.iloc[0]["row"], 1) == 1107.6
+    assert np.round(pixel_locations.iloc[0]["column"], 1) == 1087.8


### PR DESCRIPTION
Updating dependency to `pandas v2.0`. This does not change any of the code, but it was necessary to make `tess-ephem` compatible with the new version of `tesscube` and `tess-asteroids`.