### PR TITLE
Update use of tesswcs to decrease runtime

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tess-ephem"
-version = "0.6.0"
+version = "0.6.1"
 description = "Where are Solar System objects located in TESS FFI data?"
 license = "MIT"
 authors = ["Geert Barentsen <hello@geert.io>",

--- a/src/tess_ephem/__init__.py
+++ b/src/tess_ephem/__init__.py
@@ -6,5 +6,5 @@ log.addHandler(logging.StreamHandler())
 
 from .ephem import TessEphem, ephem  # noqa: E402
 
-__version__ = "0.6.0"
+__version__ = "0.6.1"
 __all__ = ["ephem", "TessEphem"]

--- a/src/tess_ephem/ephem.py
+++ b/src/tess_ephem/ephem.py
@@ -168,6 +168,8 @@ class TessEphem:
         if len(df) == 0:
             log.warning("Warning: Target not observed by TESS at defined times.")
         else:
+            # Reorder df in ascending time
+            df = df.sort_values(by="time", ascending=True)
             # Make column names lowercase in df
             df.columns = [x.lower() for x in df.columns]
             # Make sector, camera, ccd integers


### PR DESCRIPTION
In this PR, we update the use of `tesswcs` to significantly decrease runtime. 

We use the function `get_pixel_locations()` function from `tesswcs`. Previously, we were calling this at every time. However, in this update, we now call it once per unique queried sector. This significantly decreases the runtime and gives the same result.

 